### PR TITLE
Add cssnano with the safe flag to the list of minifiers.

### DIFF
--- a/lib/minifiers.js
+++ b/lib/minifiers.js
@@ -52,6 +52,11 @@ var minifiers = {
       return result.css;
     });
   },
+  'cssnano (safe)': function (source) {
+    return cssnano.process(source, {safe: true}).then(function (result) {
+      return result.css;
+    });
+  },
   'csso': function(source) {
     return csso.minify(source).css;
   },


### PR DESCRIPTION
With the `safe` flag enabled, cssnano passes the suite. I'm going to overhaul this behaviour for version 4 (`safe` by default), but it would be nice to show that it does pass when you turn off the more risky optimisations.